### PR TITLE
Refactor(PFM-40): Replacing SQLite By PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL_SQLITE="file:./dev.db"
+DATABASE_URL_POSTGRESQL="postgresql://pfm:pfm@localhost:5432/dev_db/"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "yarn assets:build && yarn sass:build && remix build",
     "start": "remix-serve build",
     "seed:db": "node --require esbuild-register prisma/seed.js",
+    "clear:db": "node --require esbuild-register prisma/clear.js",
     "check:db": "node --require esbuild-register prisma/check.js",
     "cont-check:db": "rm prisma/dev.db && npx prisma db push && yarn seed:db && yarn check:db"
   },

--- a/prisma/check.js
+++ b/prisma/check.js
@@ -1,4 +1,4 @@
-import { db } from "../app/utils"
+import { db } from "../app/utils/db.server"
 
 export async function deleteOneCategory() {
   return await db.category.delete({
@@ -74,6 +74,7 @@ export async function readManyTransaction() {
 }
 
 export async function addOneTransaction(
+  title = "Buying a new phone",
   note = "Buying a new phone",
   categoryId,
   date = new Date("10/4/2015"),
@@ -83,6 +84,7 @@ export async function addOneTransaction(
   categoryId = categoryId ? categoryId : id
   return await db.transaction.create({
     data: {
+      title,
       note,
       categoryId,
       date,
@@ -95,18 +97,21 @@ export async function addOneTransaction(
 export async function addManyTransaction(
   data = [
     {
+      title: "Buying a new phone",
       note: "Buying a new phone",
       category: "TECH",
       date: new Date("10/4/2015"),
       amount: 1_000,
     },
     {
+      title: "Peanut",
       note: "Peanut",
       category: "FOOD",
       date: new Date("8/2/1999"),
       amount: 10,
     },
     {
+      title: "Birthday Gift",
       note: "Birthday Gift",
       category: "GIFT",
       date: new Date(),

--- a/prisma/clear.js
+++ b/prisma/clear.js
@@ -1,0 +1,16 @@
+import { db } from "../app/utils/db.server"
+
+export async function deleteAllCategories() {
+  return await db.category.deleteMany()
+}
+
+export async function deleteAllTransactions() {
+  return await db.transaction.deleteMany()
+}
+
+export default async function deleteAllData() {
+  await deleteAllCategories()
+  await deleteAllTransactions()
+}
+
+deleteAllData()

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL_POSTGRESQL")
 }
 
 model Category {


### PR DESCRIPTION
**Prisma** does not support text base search using **SQLite**, so for implementing Transaction search depending on their `note`, we should switch to **PostgreSQL**.