### PR TITLE
Fix(PFM-42): Reconstructing Database Interface

### DIFF
--- a/app/utils/db.server.js
+++ b/app/utils/db.server.js
@@ -1,24 +1,14 @@
 import { PrismaClient } from "@prisma/client"
 
-const dbGenerator = (function () {
-  let instance = undefined
+let db
 
-  return {
-    getInstance: function () {
-      if (process.env.NODE_ENV === "production") {
-        instance = new PrismaClient()
-        return instance
-      } else {
-        if (!instance) {
-          instance = new PrismaClient()
-          delete instance.constructor
-        }
-        return instance
-      }
-    },
+if (process.env.NODE_ENV === "production") {
+  db = new PrismaClient()
+} else {
+  if (!global.db) {
+    global.db = new PrismaClient()
   }
-})()
-
-const db = dbGenerator.getInstance()
+  db = global.db
+}
 
 export { db }


### PR DESCRIPTION
While restarting the server, the server will create a new connection with the database, in order to have one connection we reconstructed the `db.server.js` that is used as the database interface.